### PR TITLE
make Crc32 map to instruction

### DIFF
--- a/src/System.Runtime.CompilerServices.Intrinsics/System/Runtime/CompilerServices/AVX2.cs
+++ b/src/System.Runtime.CompilerServices.Intrinsics/System/Runtime/CompilerServices/AVX2.cs
@@ -8,14 +8,13 @@ namespace System.Runtime.CompilerServices
         public static uint PopulationCount(uint value) { throw new NotImplementedException(); }
         public static uint PopulationCount(long value) { throw new NotImplementedException(); }
         public static uint PopulationCount(ulong value) { throw new NotImplementedException(); }
-
+        
         public static uint LeadingZeroCount(int value) { throw new NotImplementedException(); }
         public static uint LeadingZeroCount(uint value) { throw new NotImplementedException(); }
         public static uint LeadingZeroCount(long value) { throw new NotImplementedException(); }
         public static uint LeadingZeroCount(ulong value) { throw new NotImplementedException(); }
 
-        public static unsafe uint Crc32(byte[] data, uint length) { throw new NotImplementedException(); }
-        public static unsafe uint Crc32(byte* data, uint length) { throw new NotImplementedException(); }
-        public static unsafe uint Crc32(IntPtr data, uint length) { throw new NotImplementedException(); }
+        public static uint Crc32(uint val1, uint val2) { throw new NotImplementedException(); }
+        public static ulong Crc32(ulong val1, ulong val2) { throw new NotImplementedException(); }
     }
 }


### PR DESCRIPTION
Most use cases of crc32 would be 32bit or 64bit operands for speed in different addressing modes.
Typical usage pattern of crc32 is to feed back result into first operand for stream of data, so it's less usable to offer signed version (I suppose you can, but only after going through BitConverter to read signed value as unsigned? AFAIW, JIT types seem to only represent bits and length, not signedness.